### PR TITLE
bump to v1.32

### DIFF
--- a/data-scraper/pkg/cmds/api_lifecycle.go
+++ b/data-scraper/pkg/cmds/api_lifecycle.go
@@ -15,7 +15,7 @@ import (
 )
 
 const ScrapMinVersion = "1.5"
-const ScrapMaxVersion = "1.30"
+const ScrapMaxVersion = "1.31"
 
 type apiLifecycleCmdOptions struct {
 	Write      string

--- a/data-scraper/pkg/cmds/api_lifecycle.go
+++ b/data-scraper/pkg/cmds/api_lifecycle.go
@@ -15,7 +15,7 @@ import (
 )
 
 const ScrapMinVersion = "1.5"
-const ScrapMaxVersion = "1.31"
+const ScrapMaxVersion = "1.32"
 
 type apiLifecycleCmdOptions struct {
 	Write      string


### PR DESCRIPTION
或者这里从 https://cdn.dl.k8s.io/release/stable.txt 取最新stable 版本 目前是 v1.32.0